### PR TITLE
Potential fix for code scanning alert no. 14: Flask app is run in debug mode

### DIFF
--- a/plugins/example/notifications/memorii/main.py
+++ b/plugins/example/notifications/memorii/main.py
@@ -609,4 +609,5 @@ def status():
 start_time = time.time()
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5001, debug=True) 
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port=5001, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/14](https://github.com/guruh46/omi/security/code-scanning/14)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can easily switch between development and production environments without changing the code.

1. Modify the `app.run` call to use an environment variable to determine whether to run in debug mode.
2. Update the code to read the environment variable and set the debug mode accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
