### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -576,7 +576,8 @@ async def verify_twitter_ownership_tweet(
     persona = None
     res = await verify_latest_tweet(username, handle)
     if res['verified']:
-        if not ('google.com' in provider_data or 'apple.com' in provider_data):
+        allowed_providers = {'google.com', 'apple.com'}
+        if not any(provider in allowed_providers for provider in provider_data):
             persona = await upsert_persona_from_twitter_profile(username, handle, uid)
         else:
             if persona_id:


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/3](https://github.com/guruh46/omi/security/code-scanning/3)

To fix the problem, we need to ensure that the provider ID is checked correctly without relying on substring matching. We can achieve this by using a more robust method to verify the provider ID, such as checking for exact matches in a predefined list of allowed providers.

- Replace the substring check with a check that ensures the provider ID is exactly 'google.com' or 'apple.com'.
- Update the code on line 579 to use a set of allowed providers and check for membership in that set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
