### PR TITLE
Potential fix for code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/plugins/example/notifications/memorii/main.py
+++ b/plugins/example/notifications/memorii/main.py
@@ -591,7 +591,7 @@ def webhook():
         
     except Exception as e:
         logger.error(f"Error processing webhook request: {str(e)}", exc_info=True)
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 @app.route('/webhook/setup-status', methods=['GET'])
 def setup_status():


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/10](https://github.com/guruh46/omi/security/code-scanning/10)

To fix the problem, we should replace the detailed error message returned to the user with a generic error message. The detailed error message should be logged on the server for debugging purposes. This can be achieved by modifying the exception handling block in the `webhook` function.

- Replace the line that returns the detailed error message with a line that returns a generic error message.
- Ensure that the detailed error message is still logged on the server for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
