### PR TITLE
Potential fix for code scanning alert no. 26: Incomplete URL substring sanitization

### DIFF
--- a/personas-open-source/src/app/u/[username]/layout.tsx
+++ b/personas-open-source/src/app/u/[username]/layout.tsx
@@ -7,8 +7,15 @@ const formatTwitterAvatarUrl = (url: string): string => {
   if (!url) return '/omi-avatar.svg';
   let formattedUrl = url.replace('http://', 'https://');
   formattedUrl = formattedUrl.replace('_normal', '');
-  if (formattedUrl.includes('pbs.twimg.com')) {
-    formattedUrl = formattedUrl.replace('/profile_images/', '/profile_images/');
+  try {
+    const parsedUrl = new URL(formattedUrl);
+    const allowedHosts = ['pbs.twimg.com'];
+    if (allowedHosts.includes(parsedUrl.host)) {
+      formattedUrl = formattedUrl.replace('/profile_images/', '/profile_images/');
+    }
+  } catch (e) {
+    console.error('Invalid URL:', e);
+    return '/omi-avatar.svg';
   }
   return formattedUrl;
 };


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/26](https://github.com/guruh46/omi/security/code-scanning/26)

To fix the problem, we need to parse the URL and check its host value instead of using a substring check. This ensures that the check handles arbitrary subdomain sequences correctly and prevents bypassing the security check by embedding the allowed host in an unexpected location.

The best way to fix the problem without changing existing functionality is to use the `URL` constructor to parse the URL and then check the host value against a whitelist of allowed hosts. This approach ensures that only URLs with the exact allowed host or its subdomains are accepted.

We need to modify the `formatTwitterAvatarUrl` function to parse the URL and check the host value. We will also need to import the `URL` constructor if it is not already available in the environment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
