### PR TITLE
Potential fix for code scanning alert no. 24: Uncontrolled data used in path expression

### DIFF
--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -19,8 +19,15 @@ headers = {
 async def send_initial_file_path(file_path: str, transcript_socket_async_send):
     print('send_initial_file_path')
     start = time.time()
+    # Define a safe base directory
+    base_path = '/safe/directory'
+    # Normalize the file path
+    normalized_path = os.path.normpath(os.path.join(base_path, file_path))
+    # Ensure the normalized path is within the base directory
+    if not normalized_path.startswith(base_path):
+        raise Exception("Invalid file path")
     # Reading and sending in chunks
-    with open(file_path, "rb") as file:
+    with open(normalized_path, "rb") as file:
         while True:
             chunk = file.read(320)
             if not chunk:


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/24](https://github.com/guruh46/omi/security/code-scanning/24)

To fix the problem, we need to ensure that the `file_path` is validated and normalized before it is used in the `open` function. This can be achieved by:
1. Normalizing the `file_path` using `os.path.normpath`.
2. Ensuring that the normalized path is within a predefined safe directory.

We will modify the `send_initial_file_path` function to include these steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
