### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/plugins/example/notifications/drinking_app.py
+++ b/plugins/example/notifications/drinking_app.py
@@ -157,7 +157,7 @@ def setup_status():
         logger.error(f"Error checking setup status: {str(e)}")
         return jsonify({
             "is_setup_completed": False,
-            "error": str(e)
+            "error": "An internal error has occurred."
         }), 500
 
 if __name__ == '__main__':


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/8](https://github.com/guruh46/omi/security/code-scanning/8)

To fix the problem, we need to ensure that detailed error information is logged on the server side, but only a generic error message is returned to the user. This can be achieved by modifying the exception handling block to log the detailed error message and return a generic message in the JSON response.

- Modify the exception handling block in the `setup_status` function to log the detailed error message using `logger.error`.
- Return a generic error message in the JSON response to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
