### PR TITLE
Potential fix for code scanning alert no. 31: Replacement of a substring with itself

### DIFF
--- a/personas-open-source/src/app/u/[username]/layout.tsx
+++ b/personas-open-source/src/app/u/[username]/layout.tsx
@@ -11,7 +11,7 @@ const formatTwitterAvatarUrl = (url: string): string => {
     const parsedUrl = new URL(formattedUrl);
     const allowedHosts = ['pbs.twimg.com'];
     if (allowedHosts.includes(parsedUrl.host)) {
-      formattedUrl = formattedUrl.replace('/profile_images/', '/profile_images/');
+      formattedUrl = formattedUrl.replace('/profile_images/', '');
     }
   } catch (e) {
     console.error('Invalid URL:', e);


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/31](https://github.com/guruh46/omi/security/code-scanning/31)

To fix the problem, we need to determine the intended replacement for the substring `'/profile_images/'`. Given the context, it is likely that the author intended to replace `'/profile_images/'` with a different path or to remove the substring entirely. Since the original code removes `'_normal'` from the URL, it is reasonable to assume that the intention might be to remove `'/profile_images/'` as well.

- Replace `'/profile_images/'` with an empty string `''` to remove the substring from the URL.
- Update line 14 in the file `personas-open-source/src/app/u/[username]/layout.tsx`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
