### PR TITLE
Potential fix for code scanning alert no. 42: Server-side request forgery

### DIFF
--- a/personas-open-source/src/app/page.tsx
+++ b/personas-open-source/src/app/page.tsx
@@ -468,10 +468,15 @@ export default function HomePage() {
     setIsCreating(true);
     try {
       if (await checkExistingProfile(cleanHandle, 'twitter')) return true;
-      const profileResponse = await fetch(`https://${process.env.NEXT_PUBLIC_RAPIDAPI_HOST}/screenname.php?screenname=${cleanHandle}`, {
+      const allowedHosts = ['api.example.com', 'api2.example.com']; // Add allowed hostnames here
+      const rapidApiHost = process.env.NEXT_PUBLIC_RAPIDAPI_HOST!;
+      if (!allowedHosts.includes(rapidApiHost)) {
+        throw new Error('Invalid API host');
+      }
+      const profileResponse = await fetch(`https://${rapidApiHost}/screenname.php?screenname=${cleanHandle}`, {
         headers: {
           'x-rapidapi-key': process.env.NEXT_PUBLIC_RAPIDAPI_KEY!,
-          'x-rapidapi-host': process.env.NEXT_PUBLIC_RAPIDAPI_HOST!,
+          'x-rapidapi-host': rapidApiHost,
         },
       });
       if (!profileResponse.ok) return false;


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/42](https://github.com/guruh46/omi/security/code-scanning/42)

To fix the SSRF vulnerability, we should avoid directly using the environment variable in the URL without validation. Instead, we can use a predefined list of allowed hostnames and select the appropriate one based on the environment variable. This approach ensures that only trusted hostnames are used in the request.

1. Define a list of allowed hostnames.
2. Validate the environment variable against this list.
3. Use the validated hostname to construct the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
