### PR TITLE
Potential fix for code scanning alert no. 41: Server-side request forgery

### DIFF
--- a/personas-open-source/src/app/page.tsx
+++ b/personas-open-source/src/app/page.tsx
@@ -41,11 +41,19 @@ const formatDate = (dateString: string): string => {
 };
 
 const fetchTwitterTimeline = async (screenname: string) => {
+  const allowedHosts = ['api.example.com', 'another-api.example.com']; // Add allowed hostnames here
+  const apiHost = process.env.NEXT_PUBLIC_RAPIDAPI_HOST!;
+
+  if (!allowedHosts.includes(apiHost)) {
+    console.error('Invalid API host:', apiHost);
+    return [];
+  }
+
   try {
-    const response = await fetch(`https://${process.env.NEXT_PUBLIC_RAPIDAPI_HOST}/timeline.php?screenname=${screenname}`, {
+    const response = await fetch(`https://${apiHost}/timeline.php?screenname=${screenname}`, {
       headers: {
         'x-rapidapi-key': process.env.NEXT_PUBLIC_RAPIDAPI_KEY!,
-        'x-rapidapi-host': process.env.NEXT_PUBLIC_RAPIDAPI_HOST!,
+        'x-rapidapi-host': apiHost,
       },
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/41](https://github.com/guruh46/omi/security/code-scanning/41)

To fix the problem, we need to ensure that the environment variable `NEXT_PUBLIC_RAPIDAPI_HOST` is validated against a whitelist of allowed hostnames. This will prevent any unintended or malicious endpoints from being used in the fetch request. We can create a list of allowed hostnames and check if the environment variable matches one of these before constructing the URL.

1. Create a whitelist of allowed hostnames.
2. Validate the `NEXT_PUBLIC_RAPIDAPI_HOST` environment variable against this whitelist.
3. If the environment variable is valid, proceed with the fetch request. Otherwise, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
