### PR TITLE
Potential fix for code scanning alert no. 50: Full server-side request forgery

### DIFF
--- a/backend/utils/stt/vad.py
+++ b/backend/utils/stt/vad.py
@@ -17,6 +17,10 @@ AUTHORIZED_VAD_API_URLS = [
     "https://trusted-vad-api2.com"
 ]
 
+def validate_vad_api_url(vad_api_url):
+    if vad_api_url not in AUTHORIZED_VAD_API_URLS:
+        raise HTTPException(status_code=400, detail="Unauthorized VAD API URL")
+
 def validate_vad_api_url(url):
     if url not in AUTHORIZED_VAD_API_URLS:
         raise HTTPException(status_code=400, detail="Invalid VAD API URL")


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/50](https://github.com/guruh46/omi/security/code-scanning/50)

To fix the problem, we need to ensure that the `vad_api_url` is validated against a list of authorized URLs before making the HTTP request. This can be done by checking if the `vad_api_url` is in the `AUTHORIZED_VAD_API_URLS` list. If it is not, we should raise an exception to prevent the SSRF attack.

1. Add a function to validate the `vad_api_url` against the `AUTHORIZED_VAD_API_URLS` list.
2. Call this validation function before making the HTTP request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
