### PR TITLE
Potential fix for code scanning alert no. 23: Uncontrolled data used in path expression

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -90,7 +90,9 @@ def retrieve_file_paths(files: List[UploadFile], uid: str):
         if time > datetime.now() or time < datetime(2024, 1, 1):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}, invalid timestamp")
 
-        path = f"{directory}{filename}"
+        path = os.path.normpath(f"{directory}{filename}")
+        if not path.startswith(os.path.abspath(directory)):
+            raise HTTPException(status_code=400, detail=f"Invalid file path {filename}")
         paths.append(path)
         with open(path, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/23](https://github.com/guruh46/omi/security/code-scanning/23)

To fix the problem, we need to ensure that the constructed file paths are contained within a safe root directory. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the intended base directory. This will prevent any attempts to traverse outside the allowed directory.

1. Normalize the path using `os.path.normpath`.
2. Check that the normalized path starts with the base directory.
3. Raise an exception if the path is not within the allowed directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
