### PR TITLE
Potential fix for code scanning alert no. 13: Flask app is run in debug mode

### DIFF
--- a/plugins/example/notifications/mentor/main.py
+++ b/plugins/example/notifications/mentor/main.py
@@ -254,4 +254,5 @@ def status():
 start_time = time.time()
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port=5000, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/13](https://github.com/guruh46/omi/security/code-scanning/13)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production environments without changing the code.

We will:
1. Import the `os` module if it is not already imported.
2. Use the `os.getenv` method to get the value of an environment variable (e.g., `FLASK_DEBUG`).
3. Set the `debug` parameter of `app.run` based on the value of this environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
