### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/plugins/example/notifications/hey_omi.py
+++ b/plugins/example/notifications/hey_omi.py
@@ -243,7 +243,7 @@ def setup_status():
         logger.error(f"Error checking setup status: {str(e)}")
         return jsonify({
             "is_setup_completed": False,
-            "error": str(e)
+            "error": "An internal error has occurred."
         }), 500
 
 @app.route('/status', methods=['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/9](https://github.com/guruh46/omi/security/code-scanning/9)

To fix the problem, we need to modify the exception handling in the `setup_status` route to ensure that detailed error information is not exposed to the user. Instead, we will log the detailed error message on the server and return a generic error message to the user.

- Modify the exception handling block in the `setup_status` route to log the detailed error message using `logger.error`.
- Return a generic error message to the user without exposing the stack trace or detailed exception information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
