### PR TITLE
Potential fix for code scanning alert no. 38: Server-side request forgery

### DIFF
--- a/frontend/src/components/dashboard/paidamount.tsx
+++ b/frontend/src/components/dashboard/paidamount.tsx
@@ -1,5 +1,5 @@
 'use client';
-import envConfig from '@/src/constants/envConfig';
+import envConfig, { isValidApiUrl } from '@/src/constants/envConfig';
 
 import { useState } from 'react';
 import { DollarSign } from 'lucide-react';
@@ -32,6 +32,9 @@ export default function PaidAmountDialog({ plugin }: { plugin: Plugin }) {
     const amount = formData.get('amount') as string;
     //const adminKey = formData.get('adminKey') as string;
     try {
+      if (!isValidApiUrl(envConfig.API_URL)) {
+        throw new Error('Invalid API URL');
+      }
       const response = await fetch(`${envConfig.API_URL}/v1/plugins/report-comp`, {
         method: 'POST',
         headers: {

--- a/frontend/src/constants/envConfig.ts
+++ b/frontend/src/constants/envConfig.ts
@@ -1,3 +1,8 @@
+const ALLOWED_API_URLS = [
+  'https://api.example.com',
+  'https://api.anotherexample.com',
+];
+
 const envConfig = {
   API_URL: process.env.API_URL,
   NODE_ENV: process.env.NEXT_PUBLIC_NODE_ENV,
@@ -9,5 +14,9 @@ const envConfig = {
   ALGOLIA_INDEX_NAME: process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'memories',
   ADMIN_KEY: process.env.ADMIN_KEY,
 };
+
+export function isValidApiUrl(url) {
+  return ALLOWED_API_URLS.includes(url);
+}
 
 export default envConfig;


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/38](https://github.com/guruh46/omi/security/code-scanning/38)

To fix the problem, we need to ensure that the `API_URL` used in the `fetch` request is validated and restricted to a known set of safe URLs. This can be achieved by implementing an allow-list of acceptable URLs and ensuring that the `API_URL` from the environment variables matches one of these allowed URLs before making the request.

1. Define an allow-list of acceptable base URLs in the `envConfig` file.
2. Validate the `API_URL` against this allow-list before using it in the `fetch` request.
3. If the `API_URL` is not in the allow-list, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
