### PR TITLE
Potential fix for code scanning alert no. 35: Server-side request forgery

### DIFF
--- a/frontend/src/actions/memories/get-shared-memory.ts
+++ b/frontend/src/actions/memories/get-shared-memory.ts
@@ -4,6 +4,13 @@ import { Memory } from '@/src/types/memory.types';
 
 export default async function getSharedMemory(id: string) {
   try {
+    if (!envConfig.ALLOWED_API_URLS.includes(envConfig.API_URL)) {
+      throw new Error('Invalid API URL');
+    }
+    const idPattern = /^[a-fA-F0-9-]{36}$/; // Example pattern for UUID
+    if (!idPattern.test(id)) {
+      throw new Error('Invalid ID format');
+    }
     const response = await fetch(`${envConfig.API_URL}/v1/memories/${id}/shared`, {
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/constants/envConfig.ts
+++ b/frontend/src/constants/envConfig.ts
@@ -8,6 +8,7 @@ const envConfig = {
   ALGOLIA_SEARCH_API_KEY: process.env.NEXT_PUBLIC_ALGOLIA_API_KEY ?? '',
   ALGOLIA_INDEX_NAME: process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'memories',
   ADMIN_KEY: process.env.ADMIN_KEY,
+  ALLOWED_API_URLS: ['https://api.example.com', 'https://api.anotherexample.com'],
 };
 
 export default envConfig;


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/35](https://github.com/guruh46/omi/security/code-scanning/35)

To fix the problem, we need to ensure that the `API_URL` is validated against a known list of allowed URLs or domains. This can be achieved by introducing a whitelist of allowed URLs or domains and checking the `API_URL` against this list before making the request. Additionally, we should validate the `id` parameter to ensure it conforms to expected formats (e.g., UUID).

1. Create a whitelist of allowed URLs or domains in the `envConfig` file.
2. Validate the `API_URL` against this whitelist before constructing the URL for the `fetch` request.
3. Validate the `id` parameter to ensure it conforms to the expected format.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
