### PR TITLE
Potential fix for code scanning alert no. 34: Server-side request forgery

### DIFF
--- a/frontend/src/actions/trends/get-trends.ts
+++ b/frontend/src/actions/trends/get-trends.ts
@@ -1,8 +1,12 @@
 'use server';
-import envConfig from '@/src/constants/envConfig';
+import envConfig, { isValidApiUrl } from '@/src/constants/envConfig';
 
 export default async function getTrends() {
   try {
+    if (!isValidApiUrl(envConfig.API_URL)) {
+      throw new Error('Invalid API URL');
+    }
+
     const response = await fetch(`${envConfig.API_URL}/v1/trends`, {
       cache: 'no-cache',
     });

--- a/frontend/src/constants/envConfig.ts
+++ b/frontend/src/constants/envConfig.ts
@@ -1,3 +1,5 @@
+const allowedUrls = ['https://api.example.com', 'https://api.anotherexample.com'];
+
 const envConfig = {
   API_URL: process.env.API_URL,
   NODE_ENV: process.env.NEXT_PUBLIC_NODE_ENV,
@@ -9,5 +11,9 @@ const envConfig = {
   ALGOLIA_INDEX_NAME: process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'memories',
   ADMIN_KEY: process.env.ADMIN_KEY,
 };
+
+export function isValidApiUrl(url) {
+  return allowedUrls.includes(url);
+}
 
 export default envConfig;


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/34](https://github.com/guruh46/omi/security/code-scanning/34)

To fix the problem, we need to ensure that the URL used in the `fetch` request is not directly influenced by potentially untrusted environment variables. One way to achieve this is by validating the `API_URL` against a whitelist of allowed URLs. This ensures that only predefined, trusted URLs can be used in the request.

1. Create a whitelist of allowed URLs in the `envConfig` file.
2. Validate the `API_URL` against this whitelist before using it in the `fetch` request.
3. If the `API_URL` is not in the whitelist, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
