### PR TITLE
Potential fix for code scanning alert no. 32: Server-side request forgery

### DIFF
--- a/OpenGlass/sources/modules/ollama.ts
+++ b/OpenGlass/sources/modules/ollama.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { backoff } from "../utils/time";
 import { trimIdent } from '../utils/trimIdent';
 import { toBase64 } from '../utils/base64';
-import { keys } from '../keys';
+import { keys, allowedUrls } from '../keys';
 
 // export const ollama = new Ollama({ host: 'https://ai-1.korshakov.com' });
 
@@ -28,6 +28,10 @@ export async function ollamaInference(args: {
                 content: trimIdent(message.content),
                 images: message.images ? message.images.map((image) => toBase64(image)) : undefined,
             });
+        }
+
+        if (!allowedUrls.includes(keys.ollama)) {
+            throw new Error('Invalid URL');
         }
 
         let resp = await axios.post(keys.ollama, {


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/32](https://github.com/guruh46/omi/security/code-scanning/32)

To fix the problem, we need to ensure that the URL used in the `axios.post` request is not directly influenced by untrusted input. One way to achieve this is to validate the environment variable against a list of allowed URLs or domains. This ensures that only trusted URLs are used in the request.

We will implement a function to validate the URL and modify the `ollamaInference` function to use this validation before making the request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
