### PR TITLE
Potential fix for code scanning alert no. 45: Full server-side request forgery

### DIFF
--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -8,7 +8,10 @@ from database.apps import update_app_in_db, upsert_app_to_db, get_persona_by_id_
 from database.redis_db import delete_generic_cache, save_username, is_username_taken
 from utils.llm import condense_tweets, generate_twitter_persona_prompt
 
+authorized_hosts = ["api.twitter.com", "another.trusted.host"]
 rapid_api_host = os.getenv('RAPID_API_HOST')
+if rapid_api_host not in authorized_hosts:
+    raise ValueError("Unauthorized API host")
 rapid_api_key = os.getenv('RAPID_API_KEY')
 
 defaultTimeoutSec = 15


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/45](https://github.com/guruh46/omi/security/code-scanning/45)

To fix the problem, we need to ensure that the `rapid_api_host` variable is validated before being used to construct the URL. One way to do this is to maintain a list of authorized hosts and check if the `rapid_api_host` is in this list. This approach ensures that only trusted hosts are used in the HTTP requests.

1. Create a list of authorized hosts.
2. Validate the `rapid_api_host` against this list.
3. If the `rapid_api_host` is not in the list, raise an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
