### PR TITLE
Potential fix for code scanning alert no. 46: Full server-side request forgery

### DIFF
--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -14,10 +14,15 @@ if rapid_api_host not in authorized_hosts:
     raise ValueError("Invalid RAPID_API_HOST")
 rapid_api_key = os.getenv('RAPID_API_KEY')
 
+def construct_url(endpoint: str, handle: str) -> str:
+    if rapid_api_host not in authorized_hosts:
+        raise ValueError("Invalid RAPID_API_HOST")
+    return f"https://{rapid_api_host}/{endpoint}?screenname={handle}"
+
 defaultTimeoutSec = 15
 
 async def get_twitter_profile(handle: str) -> Dict[str, Any]:
-    url = f"https://{rapid_api_host}/screenname.php?screenname={handle}"
+    url = construct_url("screenname.php", handle)
 
     headers = {
         "X-RapidAPI-Key": rapid_api_key,
@@ -31,7 +36,7 @@ async def get_twitter_profile(handle: str) -> Dict[str, Any]:
 
 async def get_twitter_timeline(handle: str) -> Dict[str, Any]:
     print("Fetching Twitter timeline...")
-    url = f"https://{rapid_api_host}/timeline.php?screenname={handle}"
+    url = construct_url("timeline.php", handle)
 
     headers = {
         "X-RapidAPI-Key": rapid_api_key,
@@ -45,7 +50,7 @@ async def get_twitter_timeline(handle: str) -> Dict[str, Any]:
 
 async def verify_latest_tweet(username: str, handle: str) -> Dict[str, Any]:
     print("Fetching latest tweet...")
-    url = f"https://{rapid_api_host}/timeline.php?screenname={handle}"
+    url = construct_url("timeline.php", handle)
 
     headers = {
         "X-RapidAPI-Key": rapid_api_key,


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/46](https://github.com/guruh46/omi/security/code-scanning/46)

To fix the problem, we need to ensure that the `rapid_api_host` is validated every time it is used to construct a URL. This can be done by creating a helper function that validates the host and then constructs the URL. This function will be used in place of directly constructing the URL in the `get_twitter_profile`, `get_twitter_timeline`, and `verify_latest_tweet` functions.

1. Create a helper function `construct_url` that validates the host and constructs the URL.
2. Replace the direct URL construction in the `get_twitter_profile`, `get_twitter_timeline`, and `verify_latest_tweet` functions with a call to the `construct_url` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
