### PR TITLE
Potential fix for code scanning alert no. 34: Server-side request forgery

### DIFF
--- a/frontend/src/actions/trends/get-trends.ts
+++ b/frontend/src/actions/trends/get-trends.ts
@@ -1,8 +1,11 @@
 'use server';
-import envConfig from '@/src/constants/envConfig';
+import envConfig, { isValidApiUrl } from '@/src/constants/envConfig';
 
 export default async function getTrends() {
   try {
+    if (!isValidApiUrl(envConfig.API_URL)) {
+      throw new Error('Invalid API URL');
+    }
     const response = await fetch(`${envConfig.API_URL}/v1/trends`, {
       cache: 'no-cache',
     });


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/34](https://github.com/guruh46/omi/security/code-scanning/34)

To fix the problem, we need to ensure that the `API_URL` used in the `fetch` request is validated against a list of allowed URLs. This can be done by using the `isValidApiUrl` function to check if the `API_URL` is in the `ALLOWED_API_URLS` list before making the request. If the `API_URL` is not valid, we should handle the error appropriately.

1. Import the `isValidApiUrl` function from `envConfig`.
2. Validate the `API_URL` before making the `fetch` request.
3. Handle the case where the `API_URL` is not valid by returning an appropriate error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
