### PR TITLE
Potential fix for code scanning alert no. 36: Server-side request forgery

### DIFF
--- a/frontend/src/app/apps/popular/page.tsx
+++ b/frontend/src/app/apps/popular/page.tsx
@@ -4,6 +4,10 @@ import { CategoryNav } from '../components/category-nav';
 import type { Plugin, PluginStat } from '../components/types';
 
 async function getPluginsData() {
+  if (!envConfig.isValidApiUrl(envConfig.API_URL)) {
+    throw new Error('Invalid API URL');
+  }
+
   const [pluginsResponse, statsResponse] = await Promise.all([
     fetch(`${envConfig.API_URL}/v1/approved-apps?include_reviews=true`, {
       cache: 'no-store',

--- a/frontend/src/constants/envConfig.ts
+++ b/frontend/src/constants/envConfig.ts
@@ -20,4 +20,5 @@ export function isValidApiUrl(url) {
   return ALLOWED_API_URLS.includes(url);
 }
 
+export { isValidApiUrl };
 export default envConfig;


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/36](https://github.com/guruh46/omi/security/code-scanning/36)

To fix the problem, we need to ensure that the `API_URL` used in the `fetch` request is validated against a list of allowed URLs. We can use the `isValidApiUrl` function to perform this validation. If the `API_URL` is not valid, we should throw an error or handle it appropriately to prevent the SSRF vulnerability.

1. Validate the `API_URL` using the `isValidApiUrl` function before making the `fetch` request.
2. If the `API_URL` is not valid, handle the error appropriately (e.g., throw an error or use a default URL).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
