### PR TITLE
Potential fix for code scanning alert no. 36: Server-side request forgery

### DIFF
--- a/frontend/src/app/apps/popular/page.tsx
+++ b/frontend/src/app/apps/popular/page.tsx
@@ -8,8 +8,14 @@ async function getPluginsData() {
     throw new Error('Invalid API URL');
   }
 
+  if (!envConfig.isValidApiUrl(envConfig.API_URL)) {
+    throw new Error('Invalid API URL');
+  }
+
+  const apiUrl = new URL('/v1/approved-apps?include_reviews=true', envConfig.API_URL).toString();
+
   const [pluginsResponse, statsResponse] = await Promise.all([
-    fetch(`${envConfig.API_URL}/v1/approved-apps?include_reviews=true`, {
+    fetch(apiUrl, {
       cache: 'no-store',
     }),
     fetch(


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/36](https://github.com/guruh46/omi/security/code-scanning/36)

To fix the problem, we need to ensure that the `API_URL` is validated right before it is used in the `fetch` call. This can be done by re-checking the `API_URL` against the `ALLOWED_API_URLS` list at the point of use. Additionally, we can use the `URL` constructor to safely construct the URL, which will help prevent any potential path traversal issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
