### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -4,10 +4,11 @@ import threading
 import time
 from datetime import datetime
 from typing import List
-
+import re
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
 from opuslib import Decoder
 from pydub import AudioSegment
+from werkzeug.utils import secure_filename
 
 from database.memories import get_closest_memory_to_timestamps, update_memory_segments
 from models.memory import CreateMemory
@@ -71,11 +72,13 @@ def get_timestamp_from_path(path: str):
 
 
 def retrieve_file_paths(files: List[UploadFile], uid: str):
+    if not re.match(r'^[a-zA-Z0-9_-]+$', uid):
+        raise HTTPException(status_code=400, detail="Invalid user ID")
     directory = f'syncing/{uid}/'
     os.makedirs(directory, exist_ok=True)
     paths = []
     for file in files:
-        filename = file.filename
+        filename = secure_filename(file.filename)
         # Validate the file is .bin and contains a _$timestamp.bin, if not, 400 bad request
         if not filename.endswith('.bin'):
             raise HTTPException(status_code=400, detail=f"Invalid file format {filename}")


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/20](https://github.com/guruh46/omi/security/code-scanning/20)

To fix the problem, we need to ensure that the `uid` is properly validated and sanitized before using it to construct directory paths. One way to achieve this is by using a regular expression to ensure that the `uid` contains only valid characters (e.g., alphanumeric characters and hyphens). Additionally, we can use `werkzeug.utils.secure_filename` to sanitize the filenames.

1. Validate the `uid` using a regular expression to ensure it contains only valid characters.
2. Use `werkzeug.utils.secure_filename` to sanitize the filenames before using them in path expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
