### PR TITLE
Potential fix for code scanning alert no. 16: Uncontrolled data used in path expression

### DIFF
--- a/plugins/example/advanced/openglass.py
+++ b/plugins/example/advanced/openglass.py
@@ -51,7 +51,10 @@ def open_glass_example(memory: Memory, uid: str):
         return {}
 
     print(json.dumps(memory.dict(), indent=2, default=str))
-    directory = f'tmp/{uid}'
+    base_path = 'tmp'
+    directory = os.path.normpath(os.path.join(base_path, uid))
+    if not directory.startswith(base_path):
+        raise Exception("Invalid directory path")
     os.makedirs(directory, exist_ok=True)
 
     total_faces = 0


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/16](https://github.com/guruh46/omi/security/code-scanning/16)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the intended root directory. This will prevent directory traversal attacks and ensure that the `uid` value does not lead to unintended file access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
