### PR TITLE
Potential fix for code scanning alert no. 12: Flask app is run in debug mode

### DIFF
--- a/plugins/example/notifications/hey_omi.py
+++ b/plugins/example/notifications/hey_omi.py
@@ -257,4 +257,5 @@ def status():
 start_time = time.time()
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port=5000, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/12](https://github.com/guruh46/omi/security/code-scanning/12)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production configurations without changing the code.

We will modify the `app.run` call to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode. This change will be made in the `if __name__ == '__main__':` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
