### PR TITLE
Potential fix for code scanning alert no. 11: Flask app is run in debug mode

### DIFF
--- a/plugins/example/notifications/drinking_app.py
+++ b/plugins/example/notifications/drinking_app.py
@@ -161,4 +161,5 @@ def setup_status():
         }), 500
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'false').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port=5000, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/11](https://github.com/guruh46/omi/security/code-scanning/11)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the debug mode based on an environment variable. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Import the `os` module if it is not already imported.
2. Modify the `app.run` call to set the `debug` parameter based on an environment variable, such as `FLASK_DEBUG`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
