### PR TITLE
Potential fix for code scanning alert no. 50: Full server-side request forgery

### DIFF
--- a/backend/utils/stt/vad.py
+++ b/backend/utils/stt/vad.py
@@ -23,6 +23,9 @@ def is_valid_vad_api_url(url):
 def is_valid_vad_api_url(url):
     return url in AUTHORIZED_VAD_API_URLS
 
+def is_valid_vad_api_url(url):
+    return url in AUTHORIZED_VAD_API_URLS
+
 def validate_vad_api_url(vad_api_url):
     if vad_api_url not in AUTHORIZED_VAD_API_URLS:
         raise HTTPException(status_code=400, detail="Unauthorized VAD API URL")


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/50](https://github.com/guruh46/omi/security/code-scanning/50)

To fix the problem, we need to ensure that the `vad_api_url` is validated against a list of authorized URLs before making the HTTP request. This can be achieved by maintaining a list of authorized URLs and checking if the `vad_api_url` is in that list.

1. Define a list of authorized VAD API URLs.
2. Implement a function to check if the `vad_api_url` is in the list of authorized URLs.
3. Use this function to validate the `vad_api_url` before making the HTTP request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
