### PR TITLE
Potential fix for code scanning alert no. 56: Full server-side request forgery

### DIFF
--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -16,14 +16,16 @@ if rapid_api_host not in authorized_hosts:
 rapid_api_key = os.getenv('RAPID_API_KEY')
 
 def get_validated_rapid_api_host() -> str:
-    if rapid_api_host not in authorized_hosts:
+    host_mapping = {
+        "trustedhost1": "trustedhost1.com",
+        "trustedhost2": "trustedhost2.com"
+    }
+    if rapid_api_host not in host_mapping:
         raise ValueError("Invalid RAPID_API_HOST")
-    return rapid_api_host
+    return host_mapping[rapid_api_host]
 
 def construct_url(endpoint: str, handle: str) -> str:
     validated_host = get_validated_rapid_api_host()
-    if validated_host not in authorized_hosts:
-        raise ValueError("Invalid host in URL construction")
     return f"https://{validated_host}/{endpoint}?screenname={handle}"
 
 defaultTimeoutSec = 15


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/56](https://github.com/guruh46/omi/security/code-scanning/56)

To fix the problem, we need to ensure that the `rapid_api_host` is strictly validated and cannot be manipulated to point to an unauthorized host. We can achieve this by maintaining a list of authorized hosts and selecting from this list based on the input provided. Additionally, we should ensure that the `rapid_api_host` is set to a default value if it is not in the list of authorized hosts.

1. Modify the `get_validated_rapid_api_host` function to select a host from the list of authorized hosts based on a predefined mapping.
2. Update the `construct_url` function to use the validated host.
3. Ensure that the `rapid_api_host` is set to a default value if it is not in the list of authorized hosts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
