### PR TITLE
Potential fix for code scanning alert no. 54: Clear-text logging of sensitive information

### DIFF
--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -42,7 +42,7 @@ def with_retry(operation_name: str, func: Callable[[], T]) -> T:
             delay = base_delay * (2 ** attempt)
             if attempt == max_retries - 1:
                 raise
-            print(f"Error in {operation_name} (attempt {attempt+1}/{max_retries}): An error occurred")
+            print(f"Error occurred during operation (attempt {attempt+1}/{max_retries})")
             print(f"Retrying in {delay} seconds...")
             time.sleep(delay)
     raise Exception("Maximum retries exceeded")

--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -42,7 +42,7 @@ def with_retry(operation_name: str, func: Callable[[], T]) -> T:
             delay = base_delay * (2 ** attempt)
             if attempt == max_retries - 1:
                 raise
-            print(f"Error in {operation_name} (attempt {attempt+1}/{max_retries}): {str(e)}")
+            print(f"Error in {operation_name} (attempt {attempt+1}/{max_retries}): An error occurred")
             print(f"Retrying in {delay} seconds...")
             time.sleep(delay)
     raise Exception("Maximum retries exceeded")


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/54](https://github.com/guruh46/omi/security/code-scanning/54)

To fix the problem, we should avoid logging sensitive information directly. Instead of logging the full exception message, we can log a generic error message that does not include sensitive details. This way, we maintain the ability to debug issues without exposing sensitive information.

- Replace the line that logs the exception message with a generic error message.
- Ensure that the new log message does not include any sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
