### PR TITLE
Potential fix for code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -48,8 +48,11 @@ def upload_profile(data: UploadProfile, uid: str = Depends(auth.get_current_user
 
 @router.post('/v3/upload-audio', tags=['v3'])
 def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_uid)):
-    os.makedirs(f'_temp/{uid}', exist_ok=True)
-    file_path = f"_temp/{uid}/{file.filename}"
+    base_path = os.path.join('_temp', uid)
+    os.makedirs(base_path, exist_ok=True)
+    file_path = os.path.normpath(os.path.join(base_path, file.filename))
+    if not file_path.startswith(base_path):
+        raise HTTPException(status_code=400, detail="Invalid file path.")
     with open(file_path, 'wb') as f:
         f.write(file.file.read())
 


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/18](https://github.com/guruh46/omi/security/code-scanning/18)

To fix the problem, we need to ensure that the constructed file path is safe and does not allow for directory traversal attacks. This can be achieved by normalizing the path and ensuring it is contained within a designated safe directory.

1. Normalize the `file_path` using `os.path.normpath` to remove any ".." segments.
2. Ensure that the normalized path starts with the intended base directory.
3. Raise an exception if the path is not within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
