### PR TITLE
Potential fix for code scanning alert no. 17: Uncontrolled data used in path expression

### DIFF
--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -48,8 +48,15 @@ def upload_profile(data: UploadProfile, uid: str = Depends(auth.get_current_user
 
 @router.post('/v3/upload-audio', tags=['v3'])
 def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_uid)):
-    os.makedirs(f'_temp/{uid}', exist_ok=True)
-    file_path = f"_temp/{uid}/{file.filename}"
+    import re
+    if not re.match(r'^[a-zA-Z0-9_-]+$', uid):
+        raise HTTPException(status_code=400, detail="Invalid UID format")
+    base_path = '_temp'
+    user_path = os.path.normpath(os.path.join(base_path, uid))
+    if not user_path.startswith(base_path):
+        raise HTTPException(status_code=400, detail="Invalid path")
+    os.makedirs(user_path, exist_ok=True)
+    file_path = os.path.join(user_path, file.filename)
     with open(file_path, 'wb') as f:
         f.write(file.file.read())
 


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/17](https://github.com/guruh46/omi/security/code-scanning/17)

To fix the problem, we need to ensure that the `uid` is validated and sanitized before using it in the file path. We can achieve this by normalizing the path and ensuring it is contained within a safe root directory. Additionally, we can use a regular expression to validate the `uid` format.

1. Normalize the path using `os.path.normpath` to remove any ".." segments.
2. Ensure the normalized path starts with the intended root directory.
3. Validate the `uid` format using a regular expression to ensure it only contains safe characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
