### PR TITLE
Potential fix for code scanning alert no. 48: Full server-side request forgery

### DIFF
--- a/backend/utils/stt/speech_profile.py
+++ b/backend/utils/stt/speech_profile.py
@@ -14,8 +14,15 @@ def get_speech_profile_matching_predictions(uid: str, audio_file_path: str, segm
     files = [
         ('audio_file', (os.path.basename(audio_file_path), open(audio_file_path, 'rb'), 'audio/wav')),
     ]
+    base_url = os.getenv('HOSTED_SPEECH_PROFILE_API_URL')
+    if not base_url or not base_url.startswith("https://trusted-domain.com"):
+        raise ValueError("Invalid base URL")
+    
+    if not uid.isalnum():
+        raise ValueError("Invalid UID")
+    
     response = requests.post(
-        os.getenv('HOSTED_SPEECH_PROFILE_API_URL') + f'?uid={uid}',
+        f"{base_url}?uid={uid}",
         data={'segments': json.dumps(segments)},
         files=files
     )

--- a/backend/utils/stt/speech_profile.py
+++ b/backend/utils/stt/speech_profile.py
@@ -1,7 +1,7 @@
 import json
 import os
 from typing import List
-
+from urllib.parse import urlparse
 import requests
 from pydub import AudioSegment
 
@@ -15,7 +15,10 @@ def get_speech_profile_matching_predictions(uid: str, audio_file_path: str, segm
         ('audio_file', (os.path.basename(audio_file_path), open(audio_file_path, 'rb'), 'audio/wav')),
     ]
     base_url = os.getenv('HOSTED_SPEECH_PROFILE_API_URL')
-    if not base_url or not base_url.startswith("https://trusted-domain.com"):
+    if not base_url:
+        raise ValueError("Invalid base URL")
+    parsed_url = urlparse(base_url)
+    if parsed_url.scheme != "https" or parsed_url.hostname != "trusted-domain.com":
         raise ValueError("Invalid base URL")
     
     if not uid.isalnum():


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/omi/security/code-scanning/48](https://github.com/guruh46/omi/security/code-scanning/48)

To fix the SSRF vulnerability, we should ensure that the URL used in the `requests.post` call is not directly influenced by user input. One way to achieve this is to validate the `uid` parameter and ensure that the base URL from the environment variable is a trusted and fixed value. We can also use a predefined list of allowed `uid` values or sanitize the `uid` parameter to prevent malicious input.

1. Validate the `uid` parameter to ensure it meets expected criteria (e.g., alphanumeric).
2. Ensure the base URL from the environment variable is a trusted and fixed value.
3. Construct the URL using validated input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
